### PR TITLE
Save CAS return for client processing

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -102,6 +102,9 @@ function casPlugin(server, options) {
         request.session.username = result.user;
         request.session.attributes = result.attributes || {};
 
+		// Save raw cas result for processing by client
+        request.session.raw_cas = result;
+
         return addHeaders(request, reply(result).redirect(redirectPath));
       })
       .catch(function caught(error) {

--- a/plugin.js
+++ b/plugin.js
@@ -32,6 +32,8 @@ const Boom = require('boom');
  *  manager uses for tracking session identifiers.
  * @property {boolean} [strictSSL=true] Determines if the client will require
  *  valid remote SSL certificates or not.
+ * @property {boolean} [saveRawCAS=false] If true the CAS result will be
+ *  saved into session.raw_cas
  */
 
 const optsSchema = Joi.object().keys({
@@ -42,7 +44,8 @@ const optsSchema = Joi.object().keys({
   localAppUrl: Joi.string().uri({scheme: ['http', 'https']}).required(),
   endPointPath: Joi.string().regex(/^\/[\w\W\/]+\/?$/).required(),
   includeHeaders: Joi.array().items(Joi.string()).default(['cookie']),
-  strictSSL: Joi.boolean().default(true)
+  strictSSL: Joi.boolean().default(true),
+  saveRawCAS: Joi.boolean().default(false)
 });
 
 /**
@@ -102,8 +105,10 @@ function casPlugin(server, options) {
         request.session.username = result.user;
         request.session.attributes = result.attributes || {};
 
-		// Save raw cas result for processing by client
-        request.session.raw_cas = result;
+        // Save raw cas result for processing by client
+        if (_options.value.saveRawCAS) {
+          request.session.raw_cas = result;
+        }
 
         return addHeaders(request, reply(result).redirect(redirectPath));
       })


### PR DESCRIPTION
Since some CAS servers provide extra attributes in an unsupported manner, save the CAS result for client processing.

Unsupported extra attribute `user_id` is provided:

```
<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
<cas:authenticationSuccess>
  <cas:user>myusername</cas:user>
  <user_id>123</user_id>
</cas:authenticationSuccess>
</cas:serviceResponse>
```

Save the CAS result into `request.session.raw_cas`:

```
{ user: 'myusername',
  user_id: '123' }
```
