### PR TITLE
correct paren in wrong place

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -102,7 +102,7 @@ function casPlugin(server, options) {
         request.session.username = result.user;
         request.session.attributes = result.attributes || {};
 
-        return addHeaders(request, reply(result).redirect(redirectPath));
+        return addHeaders(request, reply(result)).redirect(redirectPath);
       })
       .catch(function caught(error) {
         debug('Service ticket validation failed:');


### PR DESCRIPTION
I believe the parenthesis in the return statement is in the wrong place, resulting in the return of the response object instead of performing the redirect.

Create pull request to develop, closed https://github.com/jsumners/hapi-cas/pull/2
